### PR TITLE
[#93636978] change throttle request …

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "aws-sdk": "^2.0.28",
-    "lodash": "^2.4.1",
+    "lodash": "^4.5.1",
     "lynx": "^0.2.0"
   }
 }


### PR DESCRIPTION
… to read/write throttle events metric, as throttle request is operation specific (put, update, batchWrite, etc) and did not actually monitor anything, without that being specified.

Addressing https://www.pivotaltracker.com/projects/816619/stories/93636978 we want to monitor read/write throttle events not throttledRequests. Enhancements to work with multiple metrics, now also works without prefix parameter. 

It still writes to dynamodb.throttleevents.all as before, so backward compatible to current dashboard, but we should probably change the dashboard to show read and write throttles as two lines instead.
